### PR TITLE
Import the GPG key as the root user.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ runs:
     - run: wget https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh -O guix-install.sh
       shell: bash
       name: Download
-    - run: wget "https://sv.gnu.org/people/viewgpg.php?user_id=15145" -qO - | gpg --import -
+    - run: wget "https://sv.gnu.org/people/viewgpg.php?user_id=15145" -qO - | sudo gpg --import -
       shell: bash
       name: Fetch key
     - run: echo -e 'y\ny' | sudo bash guix-install.sh


### PR DESCRIPTION
Hi @PromyLOPh,

Looking into the failing CI jobs [1], I think the GPG key is not imported by the right user.

[1] https://github.com/guix-science/guix-science/runs/2149075574

This pull request imports the GPG key as the root user instead of the regular user.