### PR TITLE
Run 'guix describe' by default.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,7 +75,5 @@ jobs:
                 (openpgp-fingerprint
                  "CA4F 8CF4 37D7 478F DA05  5FD4 4213 7701 1A37 8446"))))
              %default-channels)
-      - name: guix describe
-        run: guix describe
       - name: Build from external channel
         run: guix build python-jupyterlab

--- a/action.yml
+++ b/action.yml
@@ -58,4 +58,6 @@ runs:
         echo "$HOME/.config/guix/current/bin" >> $GITHUB_PATH
       shell: bash
       name: Set PATH
-
+    - run: guix describe -f channels-sans-intro
+      shell: bash
+      name: guix describe


### PR DESCRIPTION
It is easy to miss the channel information in the installation log.

Adding a `guix describe` step is useful to access the exact channel information for a given artifact, in case it needs to be reproduced in the future.