### PR TITLE
Get rid of GUIX_LOCPATH warning.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,8 @@ jobs:
       # Cannot use a cache for /gnu/store, since restore fails
       - name: Install Guix
         uses: PromyLOPh/guix-install-action@v1
+      - name: Ensure no locale warning
+        run: test -z "$(guix --version 2>&1 >/dev/null)"
       - name: Build hello
         run: guix build hello
       # Pack independent binary

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,12 @@ inputs:
            %default-channels)
 runs:
   using: 'composite'
-  steps: 
+  steps:
+    # The default locale on Debian and Ubuntu is "C.UTF-8" which does not exist
+    # in vanilla glibc.  Change to something that works for Guix and Debuntu.
+    - run: echo LANG=en_US.utf8 >> $GITHUB_ENV
+      shell: bash
+      name: Set LANG
     - run: |
         wget -nv https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh -O guix-install.sh
         wget -nv https://ci.guix.gnu.org/search/latest/archive?query=spec:tarball+status:success+system:x86_64-linux+guix-binary.tar.xz -O guix-binary-nightly.x86_64-linux.tar.xz


### PR DESCRIPTION
This gets rid of the Guix locale warning that mistakenly hints that `$GUIX_LOCPATH` should be set:

```
hint: Consider installing the `glibc-locales' package and defining
`GUIX_LOCPATH', along these lines:

     guix install glibc-locales
     export GUIX_LOCPATH="$HOME/.guix-profile/lib/locale"

See the "Application Setup" section in the manual, for more info.
```

The problem is that the default locale in the build environment is `C.UTF-8` which is a [Debianism](https://bugzilla.redhat.com/show_bug.cgi?id=902094).

This works around the problem by setting `LANG` to `en_US.utf-8` which happens to be available in the Ubuntu runner.