### PR TITLE
Output the channel specification.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,3 +79,11 @@ jobs:
              %default-channels)
       - name: Build from external channel
         run: guix build python-jupyterlab
+      # Test that the channels output can be pulled.  This operation should
+      # complete quickly.
+      - name: Build with time machine
+        run: |
+          cat <<EOF > ${{ runner.temp }}/channels.scm
+          ${{ steps.install-guix.outputs.channels }}
+          EOF
+          guix time-machine -C ${{ runner.temp }}/channels.scm -- build python-jupyterlab

--- a/README.rst
+++ b/README.rst
@@ -23,3 +23,10 @@ Inputs
     A Scheme expression that describes the Guix channels to use. See `manual
     <https://guix.gnu.org/manual/devel/en/guix.html#Specifying-Additional-Channels>`__
 
+
+Outputs
+-------
+
+:channels:
+     The exact channel(s) that were pulled, with commit identifiers.  The output
+     can be used as an input for this action to reproduce a previous run.

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,10 @@ inputs:
                   (url "https://github.com/guix-mirror/guix.git"))
                  chan))
            %default-channels)
+outputs:
+  channels:
+    description: 'Exact Guix channels that were used for this action.'
+    value: ${{ steps.guix-describe.outputs.channels }}
 runs:
   using: 'composite'
   steps:
@@ -63,6 +67,9 @@ runs:
         echo "$HOME/.config/guix/current/bin" >> $GITHUB_PATH
       shell: bash
       name: Set PATH
-    - run: guix describe -f channels-sans-intro
+    # Substitute newlines to work-around GitHubs single-line limitation.
+    - run: |
+        echo "::set-output name=channels::$(guix describe -f channels | tr '\n' ' ')"
       shell: bash
       name: guix describe
+      id: guix-describe


### PR DESCRIPTION
Hi!

This replaces the 'describe' step with one that stores the channel specification as an output.

This output can be saved and used as an input for a later run (e.g. to check reproducibility or restore an artifact).