### PR TITLE
Fix multiple channels test.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -64,6 +64,7 @@ jobs:
             guix-cache-
       # Cannot use a cache for /gnu/store, since restore fails
       - name: Install Guix
+        id: install-guix
         uses: PromyLOPh/guix-install-action@v1
         with:
           channels: |-


### PR DESCRIPTION
This fixes the test added in d7f71bbbcc45a75b792e23b59c4e3f5ad149cf9c by setting the `id` that the test expects.

It probably got lost when I resolved the merge conflict with which repository the test runs from.