### PR TITLE
Update test URL in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ SquashFS filesystems. See `guix pack
 information.
 
 `This repository’s test action
-<https://github.com/PromyLOPh/guix-install-action/blob/master/.github/workflows/test.yml>`__
+<https://github.com/PromyLOPh/guix-install-action/blob/v1/.github/workflows/test.yml>`__
 showcases the available options.
 
 Inputs


### PR DESCRIPTION
Hi,

I noticed that the link to the test uses a stale 'master' branch.  The last commit in this PR updates the link; I included #9 for easier merging.