### PR TITLE
Feed extra newline to the install script.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -40,7 +40,7 @@ runs:
       name: Fetch key
     - run: |
         export GUIX_BINARY_FILE_NAME=guix-binary-nightly.x86_64-linux.tar.xz
-        echo -e 'y\ny' | sudo --preserve-env=GUIX_BINARY_FILE_NAME bash guix-install.sh
+        echo -e '\ny\ny' | sudo --preserve-env=GUIX_BINARY_FILE_NAME bash guix-install.sh
       shell: bash
       name: Install Guix
     - run: sudo -i guix archive --generate-key


### PR DESCRIPTION
Hello,

I'm not sure what has changed, but recently jobs started failing on the 'Install Guix' step, printing `Please answer yes or no.` over and over for six hours.  See e.g. [here](https://github.com/unioslo/mreg/runs/3655276999?check_suite_focus=true).

There have not been any changes to [guix-install.sh](https://git.savannah.gnu.org/cgit/guix.git/log/etc/guix-install.sh), so what gives?  Recently the [guix-binary tarball](https://ci.guix.gnu.org/search?query=spec:tarball+status:success+system:x86_64-linux+guix) was updated, but I don't see how that could have this effect.

Reading the script, a newline is expected as the first input, which is what this PR implements.  Perhaps the Ubuntu runner used to add one implicitly (though I suppose that would break many more scripts!)?

At any rate this 1-byte fix is harmless and I believe backwards-compatible.