### PR TITLE
Update action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -75,7 +75,7 @@ runs:
       name: Set PATH
     # Substitute newlines to work-around GitHubs single-line limitation.
     - run: |
-        echo "::set-output name=channels::$(guix describe -f channels | tr '\n' ' ')"
+        echo echo "channels=$(guix describe -f channels | tr '\n' ' ')" >> $GITHUB_OUTPUT
       shell: bash
       name: guix describe
       id: guix-describe


### PR DESCRIPTION
`::set-output` is now deprecated, see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/