### PR TITLE
Use savannah.gnu.org address to download GPG keys

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -38,8 +38,8 @@ runs:
       shell: bash
       name: Download
     - run: |
-        wget "https://sv.gnu.org/people/viewgpg.php?user_id=127547" -qO - | sudo gpg --import -
-        wget "https://sv.gnu.org/people/viewgpg.php?user_id=15145" -qO - | sudo gpg --import -
+        wget "https://savannah.gnu.org/people/viewgpg.php?user_id=127547" -qO - | sudo gpg --import -
+        wget "https://savannah.gnu.org/people/viewgpg.php?user_id=15145" -qO - | sudo gpg --import -
       shell: bash
       name: Fetch key
     - run: |


### PR DESCRIPTION
It appears that there is a certificate issue with https://sv.gnu.org which prevents this action from installing Guix successfully as it fails at the "Fetch key" step.  This change merely uses the full savannah.gnu.org address as it doesn't seem to be affected by the certificate issue.