### PR TITLE
Maintain guix-install.sh (Fix #20)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,12 +29,23 @@ runs:
   steps:
     # The default locale on Debian and Ubuntu is "C.UTF-8" which does not exist
     # in vanilla glibc.  Change to something that works for Guix and Debuntu.
-    - run: echo LANG=en_US.utf8 >> $GITHUB_ENV
-      shell: bash
-      name: Set LANG
     - run: |
-        wget -nv https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh?h=3893758dac76fc30b23d4715e849e262306f268d -O guix-install.sh
-        wget -nv https://raw.githubusercontent.com/TxGVNN/guix-install-action/v1/guix-install.sh.patch -O guix-install.sh.patch
+        GITHUB_ACTION_REPO="PromyLOPh/guix-install-action"
+        GITHUB_ACTION_VERSION="v1"
+        if [ -n "$GITHUB_ACTION_PATH" ]; then
+            IFS='/' read -ra PARTS <<< "$GITHUB_ACTION_PATH"
+            VERSION=${PARTS[-1]}
+            GITHUB_ACTION_REPO="${PARTS[-3]}/${PARTS[-2]}"
+        fi
+        echo LANG=en_US.utf8 >> $GITHUB_ENV
+        echo GUIX_INSTALL_SH_COMMIT=3893758dac76fc30b23d4715e849e262306f268d >> $GITHUB_ENV
+        echo GITHUB_ACTION_REPO=$GITHUB_ACTION_REPO >> $GITHUB_ENV
+        echo GITHUB_ACTION_VERSION=$GITHUB_ACTION_VERSION >> $GITHUB_ENV
+      shell: bash
+      name: Set ENV
+    - run: |
+        wget -nv "https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh?h=${GUIX_INSTALL_SH_COMMIT}" -O guix-install.sh
+        wget -nv "https://raw.githubusercontent.com/${GITHUB_ACTION_REPO}/${GITHUB_ACTION_VERSION}/guix-install.sh.patch" -O guix-install.sh.patch
         patch guix-install.sh < guix-install.sh.patch
       shell: bash
       name: Download

--- a/action.yml
+++ b/action.yml
@@ -33,8 +33,9 @@ runs:
       shell: bash
       name: Set LANG
     - run: |
-        wget -nv https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh -O guix-install.sh
-        wget -nv https://ci.guix.gnu.org/search/latest/archive?query=spec:tarball+status:success+system:x86_64-linux+guix-binary.tar.xz -O guix-binary-nightly.x86_64-linux.tar.xz
+        wget -nv https://git.savannah.gnu.org/cgit/guix.git/plain/etc/guix-install.sh?h=3893758dac76fc30b23d4715e849e262306f268d -O guix-install.sh
+        wget -nv https://raw.githubusercontent.com/TxGVNN/guix-install-action/v1/guix-install.sh.patch -O guix-install.sh.patch
+        patch guix-install.sh < guix-install.sh.patch
       shell: bash
       name: Download
     - run: |
@@ -43,8 +44,7 @@ runs:
       shell: bash
       name: Fetch key
     - run: |
-        export GUIX_BINARY_FILE_NAME=guix-binary-nightly.x86_64-linux.tar.xz
-        sudo --preserve-env=GUIX_BINARY_FILE_NAME -- bash -c 'yes | bash guix-install.sh'
+        sudo -- bash guix-install.sh
       shell: bash
       name: Install Guix
     - run: sudo -i guix archive --generate-key

--- a/guix-install.sh.patch
+++ b/guix-install.sh.patch
@@ -1,0 +1,56 @@
+--- guix-install.sh	2023-03-22 21:16:56.000000000 +0700
++++ guix-install.sh.patched	2023-03-22 08:27:05.184102082 +0700
+@@ -121,9 +121,7 @@
+ # answering "yes".
+ # $1: The prompt question.
+ prompt_yes_no() {
+-    local -l yn
+-    read -rp "$1 [Y/n]" yn
+-    [[ ! $yn || $yn = y || $yn = yes ]] || return 1
++    return 0
+ }
+ 
+ chk_require()
+@@ -295,21 +293,11 @@
+     _debug "--- [ ${FUNCNAME[0]} ] ---"
+ 
+     # Filter only version and architecture
+-    bin_ver_ls=("$(wget "$gnu_url" --no-verbose -O- \
+-        | sed -n -e 's/.*guix-binary-\([0-9.]*[a-z0-9]*\)\..*.tar.xz.*/\1/p' \
+-        | sort -Vu)")
+-
+-    latest_ver="$(echo "${bin_ver_ls[0]}" \
+-                       | grep -oE "([0-9]{1,2}\.){2}[0-9]{1,2}[a-z0-9]*" \
+-                       | tail -n1)"
++    latest_ver="1.4.0"
+ 
+     default_ver="guix-binary-${latest_ver}.${ARCH_OS}"
+ 
+-    if [[ "${#bin_ver_ls}" -ne "0" ]]; then
+-        _msg "${PAS}Release for your system: ${default_ver}"
+-    else
+-        die "Could not obtain list of Guix releases."
+-    fi
++    _msg "${PAS}Release for your system: ${default_ver}"
+ 
+     # Use default to download according to the list and local ARCH_OS.
+     BIN_VER="${default_ver}"
+@@ -627,18 +615,6 @@
+ 
+ https://www.gnu.org/software/guix/
+ EOF
+-    # Don't use ‘read -p’ here!  It won't display when run non-interactively.
+-    echo -n "Press return to continue..."$'\r'
+-    if ! read -r char; then
+-	echo
+-	die "Can't read standard input.  Hint: don't pipe scripts into a shell."
+-    fi
+-    if [ "$char" ]; then
+-	echo
+-	echo "...that ($char) was not a return!"
+-	_msg "${WAR}Use newlines to automate installation, e.g.: yes '' | ${0##*/}"
+-	_msg "${WAR}Any other method is unsupported and likely to break in future."
+-    fi
+ }
+ 
+ main()


### PR DESCRIPTION
I would like to create this PR to resolve #20 by maintaining guix-install.sh. I pined version is 1.4.0

I tested on my repository https://github.com/TxGVNN/giaelpa/actions/runs/4485553955/jobs/7887221072

If you think it is fine, we need to update this line to this repo [action.yml#L36](https://github.com/TxGVNN/guix-install-action/blob/37e62acae8bbe0d4dc0ffebad5af0b5d9b0570bb/action.yml#L36) (you can tell me), after that we can squash and merge.
Other side, feel free to close if you had any plan.

Thanks