### PR TITLE
Fallback to Codeberg mirror when Savannah is down

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -100,7 +100,7 @@ runs:
         EOF
       shell: bash
       name: Create channel file
-    - run: sudo /var/guix/profiles/per-user/root/current-guix/bin/guix pull --fallback -C ${{ runner.temp }}/channels.scm
+    - run: sudo /var/guix/profiles/per-user/root/current-guix/bin/guix pull --fallback -C ${{ runner.temp }}/channels.scm || sudo /var/guix/profiles/per-user/root/current-guix/bin/guix pull --fallback -C ${{ runner.temp }}/channels.scm --url="https://codeberg.org/guix/guix-mirror"
       shell: bash
       name: Update Guix
       if: ${{ inputs.pullAfterInstall == 'true' }}


### PR DESCRIPTION
The Codeberg mirror of Guix can be safely used as a source in case pulling from Savannah fails.

This is something I've been doing in my own configuration for [over 2 weeks](https://github.com/gs-101/.files/commit/482aa23fa1cbbbdeb119e1da6649fc5db7021633), and I have not faced any issues so far. I understand if you may think this could cause breakage, and you can close this PR if you think so.